### PR TITLE
Base RAML support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
   - composer install
 
 script:
-  - bin/phpspec run
+  - vendor/bin/phpspec run

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - hhvm
 
 before_script:
-  - composer install
+  - composer install --no-interaction
 
 script:
-  - vendor/bin/phpspec run
+  - vendor/bin/phpspec run --format pretty --no-code-generation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+    - 5.6
+    - 7.0
+    - hhvm
+
+before_script:
+  - composer install
+
+script:
+  - bin/phpspec run

--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ RAML PHP Library
 
 This library aims to provide handy way to work with RAML.
 
+**WIP**: Currently this library is in development. Please stay tuned.
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
             "src/functions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "support\\Fesor\\RAML\\": "tests/support"
+        }
+    },
     "minimum-stability": "stable",
     "require": {
         "symfony/yaml": "~2.3.0|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "support\\Fesor\\RAML\\": "tests/support"
+            "support\\Fesor\\RAML\\": "tests/support/",
+            "spec\\Fesor\\RAML\\": "tests/spec/"
         }
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "symfony/yaml": "~2.3.0|~3.0"
+        "symfony/yaml": "~2.3.0|~3.0",
+        "ql/uri-template": "^1.1",
+        "symfony/options-resolver": "^3.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,114 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "47242272206457a552700f74f10f2d97",
-    "content-hash": "1d222ac7a470a686a7f332e23bb9b455",
+    "hash": "83b8a9a8e1658d8b019cdd34884c95b1",
+    "content-hash": "bb049b78239b46202a5a12333c597373",
     "packages": [
+        {
+            "name": "ql/uri-template",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/QuickenLoans/uri-template.git",
+                "reference": "ea0b70ec757658529331c7861ec39b0a58fc61a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/QuickenLoans/uri-template/zipball/ea0b70ec757658529331c7861ec39b0a58fc61a1",
+                "reference": "ea0b70ec757658529331c7861ec39b0a58fc61a1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/php-invoker": "*",
+                "phpunit/phpunit": "*",
+                "satooshi/php-coveralls": "dev-master@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "QL\\UriTemplate": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Nagi",
+                    "email": "mattnagi@quickenloans.com"
+                }
+            ],
+            "description": "An implementation of RFC 6570 level 4",
+            "homepage": "https://github.com/QuickenLoans/uri-template",
+            "keywords": [
+                "URI Template",
+                "rfc6570",
+                "template",
+                "uri",
+                "url"
+            ],
+            "time": "2015-12-09 10:44:44"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "77f7252e377e1dc021ba74defe12a19a45bb1212"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/77f7252e377e1dc021ba74defe12a19a45bb1212",
+                "reference": "77f7252e377e1dc021ba74defe12a19a45bb1212",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2016-05-09 18:14:44"
+        },
         {
             "name": "symfony/yaml",
             "version": "v3.0.6",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -4,3 +4,5 @@ suites:
         psr4_prefix: Fesor\RAML
         spec_path: %paths.config%/tests
     formatter.name: pretty
+extensions:
+  - support\Fesor\RAML\PhpSpec\Extension

--- a/src/Normalizer/AnnotationsNormalizer.php
+++ b/src/Normalizer/AnnotationsNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class AnnotationsNormalizer implements Normalizer
+{
+    private $next;
+
+    /**
+     * AnnotationsNormalizer constructor.
+     * @param Normalizer $next
+     */
+    public function __construct(Normalizer $next)
+    {
+        $this->next = $next;
+    }
+
+    public function normalize($value)
+    {
+        $annotations = $this->collectAnnotations(array_keys($value));
+        foreach ($annotations as $key => $annotation) {
+            $value['annotations'][$annotation] = $value[$key];
+        }
+
+        return $this->next->normalize(array_diff_key($value, $annotations));
+    }
+
+    private function collectAnnotations($keys)
+    {
+        return array_filter(array_map(function ($key) {
+            if (!preg_match('/^\((.+)\)$/U', $key, $matches)) {
+                return null;
+            }
+
+            return $matches[1];
+        }, array_combine($keys, $keys)));
+    }
+}

--- a/src/Normalizer/ImportNormalizer.php
+++ b/src/Normalizer/ImportNormalizer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+use Fesor\RAML\RAMLLoader;
+
+class ImportNormalizer implements Normalizer
+{
+    const IMPORT_TAG = '!include';
+
+    /**
+     * @var RAMLLoader
+     */
+    private $loader;
+
+    /**
+     * ImportNormalizer constructor.
+     * @param RAMLLoader $loader
+     */
+    public function __construct(RAMLLoader $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    public function normalize($value)
+    {
+        $value = $this->mapImports(
+            $value,
+            $this->importData($this->collectImports($value))
+        );
+
+        return $value;
+    }
+
+    private function collectImports($value)
+    {
+        $imports = [];
+        foreach ($value as $key => $node) {
+            if (!is_string($node) || 0 !== mb_strpos($node, self::IMPORT_TAG)) {
+                continue;
+            }
+
+            $imports[$key] = mb_substr($node, strlen(self::IMPORT_TAG)+1);
+        }
+
+        return $imports;
+    }
+
+    private function importData(array $imports)
+    {
+        return array_map(function ($path) {
+            return $this->loader->load($path);
+        }, $imports);
+    }
+
+    private function mapImports($value, $imports)
+    {
+        foreach($imports as $key => $importedData) {
+            $value[$key] = $importedData;
+        }
+
+        return $value;
+    }
+}

--- a/src/Normalizer/MethodNormalizer.php
+++ b/src/Normalizer/MethodNormalizer.php
@@ -6,23 +6,6 @@ class MethodNormalizer implements Normalizer
 {
     public function normalize($value)
     {
-        $methods = $this->collectMethods($value);
-        $value['methods'] = array_values($methods);
-
-        return array_diff_key($value, $methods);
-    }
-
-    private function collectMethods($value)
-    {
-        $methods = array_intersect_key($value, array_flip([
-            'get', 'patch', 'put', 'post', 'delete', 'options', 'head'
-        ]));
-
-        foreach ($methods as $httpMethod => &$methodDefinition)
-        {
-            $methodDefinition['method'] = $httpMethod;
-        }
-
-        return $methods;
+        return $value;
     }
 }

--- a/src/Normalizer/MethodNormalizer.php
+++ b/src/Normalizer/MethodNormalizer.php
@@ -4,8 +4,75 @@ namespace Fesor\RAML\Normalizer;
 
 class MethodNormalizer implements Normalizer
 {
+    private $normalizerRegistry;
+
+    /**
+     * MethodNormalizer constructor.
+     * @param NormalizerRegistry $normalizerRegistry
+     */
+    public function __construct(NormalizerRegistry $normalizerRegistry)
+    {
+        $this->normalizerRegistry = $normalizerRegistry;
+    }
+
     public function normalize($value)
     {
+        $value['headers'] = $this->normalizeHeaders(isset($value['headers']) ? $value['headers'] : []);
+        if (isset($value['body'])) {
+            $value['body'] = $this->normalizeBody($value['body']);
+        }
+
+        if (isset($value['responses'])) {
+            $value['responses'] = $this->normalizeResponses($value['responses']);
+        }
+
         return $value;
+    }
+
+    private function normalizeHeaders(array $headers)
+    {
+        return $this->normalizerRegistry
+            ->getNormalizer('properties')
+            ->normalize($headers);
+    }
+
+    private function normalizeBody($body, $checkMediaTypes = true)
+    {
+        if (!is_array($body)) {
+            $body = ['type' => $body];
+        }
+
+        $mediaTypes = array_filter(array_keys($body), 'Fesor\\RAML\\isValidMediaType');
+        if ($checkMediaTypes && count($mediaTypes) === count($body)) {
+            $normalizedBody = [];
+            foreach ($body as $mediaType => $bodyDeclaration) {
+                $normalizedBodyDeclaration = $this->normalizeBody($bodyDeclaration);
+                $normalizedBodyDeclaration['mediaType'] = $mediaType;
+            }
+
+            return $normalizedBody;
+        }
+
+        return $this->normalizerRegistry->getNormalizer('type')->normalize($body);
+    }
+
+    private function normalizeResponses(array $responses)
+    {
+        $normalizedResponses = [];
+        foreach($responses as $statusCode => $responseDeclaration) {
+            $response = $responseDeclaration;
+            $response['headers'] = $this->normalizeHeaders(
+                isset($responseDeclaration['headers']) ?
+                    $responseDeclaration['headers'] : []
+            );
+            if (isset($responseDeclaration['body'])) {
+                $response['body'] = $this->normalizeBody($responseDeclaration['body']);
+            }
+            $response['statusCode'] = $statusCode;
+
+            $normalizedResponses[] = $response;
+        }
+
+        return $normalizedResponses;
     }
 }

--- a/src/Normalizer/MethodNormalizer.php
+++ b/src/Normalizer/MethodNormalizer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class MethodNormalizer implements Normalizer
+{
+    public function normalize($value)
+    {
+        $methods = $this->collectMethods($value);
+        $value['methods'] = array_values($methods);
+
+        return array_diff_key($value, $methods);
+    }
+
+    private function collectMethods($value)
+    {
+        $methods = array_intersect_key($value, array_flip([
+            'get', 'patch', 'put', 'post', 'delete', 'options', 'head'
+        ]));
+
+        foreach ($methods as $httpMethod => &$methodDefinition)
+        {
+            $methodDefinition['method'] = $httpMethod;
+        }
+
+        return $methods;
+    }
+}

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+interface Normalizer
+{
+    public function normalize($value);
+}

--- a/src/Normalizer/NormalizerRegistry.php
+++ b/src/Normalizer/NormalizerRegistry.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class NormalizerRegistry
+{
+    private $normalizersMap;
+
+    public function addNormalizer($name, $normalizer)
+    {
+        $this->normalizersMap[$name] = $normalizer;
+    }
+
+    public function getNormalizer($name)
+    {
+        if (!isset($this->normalizersMap[$name])) {
+            throw new \RuntimeException(sprintf('Normalizer "%s" is nor registered', $name));
+        }
+
+        return $this->normalizersMap[$name];
+    }
+}

--- a/src/Normalizer/NormalizerRegistry.php
+++ b/src/Normalizer/NormalizerRegistry.php
@@ -11,6 +11,10 @@ class NormalizerRegistry
         $this->normalizersMap[$name] = $normalizer;
     }
 
+    /**
+     * @param $name
+     * @return Normalizer
+     */
     public function getNormalizer($name)
     {
         if (!isset($this->normalizersMap[$name])) {

--- a/src/Normalizer/PropertiesDeclarationNormalizer.php
+++ b/src/Normalizer/PropertiesDeclarationNormalizer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class PropertiesDeclarationNormalizer
+{
+    private $typeNormalizer;
+
+    public function __construct(Normalizer $typeNormalizer)
+    {
+        $this->typeNormalizer = $typeNormalizer;
+    }
+
+    public function normalize($value)
+    {
+        return $this->typeNormalizer->normalize([
+            'properties' => $value
+        ])['properties'];
+    }
+}

--- a/src/Normalizer/ResourcesNormalizer.php
+++ b/src/Normalizer/ResourcesNormalizer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class ResourcesNormalizer implements Normalizer
+{
+    public function normalize($value)
+    {
+        $resourcesKeys = $this->collectResourceKeys($value);
+        $resources = array_intersect_key($value, array_flip($resourcesKeys));
+        foreach ($resources as $uri => &$resource) {
+            $resource['uri'] = $uri;
+        }
+        $value['resources'] = array_map(function ($resource) {
+            return $this->normalize($resource);
+        }, array_values($resources));
+
+        return array_diff_key($value, array_flip($resourcesKeys));
+    }
+
+    private function collectResourceKeys($value)
+    {
+        return array_filter(array_keys($value), function ($key) {
+            return 0 === mb_strpos($key, '/');
+        });
+    }
+}

--- a/src/Normalizer/ResourcesNormalizer.php
+++ b/src/Normalizer/ResourcesNormalizer.php
@@ -9,22 +9,24 @@ class ResourcesNormalizer implements Normalizer
 {
     public function normalize($value)
     {
-        $resourcesKeys = $this->collectResourceKeys($value);
-        $resources = onlyWithinKeys($value, $resourcesKeys);
-        foreach ($resources as $uri => &$resource) {
-            $resource['uri'] = $uri;
-        }
-        $value['resources'] = array_map(function ($resource) {
-            return $this->normalize($resource);
-        }, array_values($resources));
+        $methods = $this->collectMethods($value);
+        $value['methods'] = array_values($methods);
+        $value = array_diff_key($value, $methods);
 
-        return excludingKeys($value, $resourcesKeys);
+        return $value;
     }
 
-    private function collectResourceKeys($value)
+    private function collectMethods($value)
     {
-        return array_filter(array_keys($value), function ($key) {
-            return 0 === mb_strpos($key, '/');
-        });
+        $methods = onlyWithinKeys($value, [
+            'get', 'patch', 'put', 'post', 'delete', 'options', 'head'
+        ]);
+
+        foreach ($methods as $httpMethod => &$methodDefinition)
+        {
+            $methodDefinition['method'] = $httpMethod;
+        }
+
+        return $methods;
     }
 }

--- a/src/Normalizer/ResourcesNormalizer.php
+++ b/src/Normalizer/ResourcesNormalizer.php
@@ -7,6 +7,13 @@ use function Fesor\RAML\onlyWithinKeys;
 
 class ResourcesNormalizer implements Normalizer
 {
+    private $methodNormalizer;
+
+    public function __construct(Normalizer $methodNormalizer)
+    {
+        $this->methodNormalizer = $methodNormalizer;
+    }
+
     public function normalize($value)
     {
         $methods = $this->collectMethods($value);
@@ -25,6 +32,7 @@ class ResourcesNormalizer implements Normalizer
         foreach ($methods as $httpMethod => &$methodDefinition)
         {
             $methodDefinition['method'] = $httpMethod;
+            $methodDefinition = $this->methodNormalizer->normalize($methodDefinition);
         }
 
         return $methods;

--- a/src/Normalizer/ResourcesNormalizer.php
+++ b/src/Normalizer/ResourcesNormalizer.php
@@ -2,12 +2,15 @@
 
 namespace Fesor\RAML\Normalizer;
 
+use function Fesor\RAML\excludingKeys;
+use function Fesor\RAML\onlyWithinKeys;
+
 class ResourcesNormalizer implements Normalizer
 {
     public function normalize($value)
     {
         $resourcesKeys = $this->collectResourceKeys($value);
-        $resources = array_intersect_key($value, array_flip($resourcesKeys));
+        $resources = onlyWithinKeys($value, $resourcesKeys);
         foreach ($resources as $uri => &$resource) {
             $resource['uri'] = $uri;
         }
@@ -15,7 +18,7 @@ class ResourcesNormalizer implements Normalizer
             return $this->normalize($resource);
         }, array_values($resources));
 
-        return array_diff_key($value, array_flip($resourcesKeys));
+        return excludingKeys($value, $resourcesKeys);
     }
 
     private function collectResourceKeys($value)

--- a/src/Normalizer/RootNormalizer.php
+++ b/src/Normalizer/RootNormalizer.php
@@ -7,15 +7,15 @@ use function Fesor\RAML\excludingKeys;
 
 class RootNormalizer implements Normalizer
 {
-    private $typeNormalizer;
+    private $normalizers;
 
     /**
      * RootNormalizer constructor.
-     * @param Normalizer $typeNormalizer
+     * @param NormalizerRegistry $normalizers
      */
-    public function __construct(Normalizer $typeNormalizer)
+    public function __construct(NormalizerRegistry $normalizers)
     {
-        $this->typeNormalizer = $typeNormalizer;
+        $this->normalizers = $normalizers;
     }
 
     public function normalize($value)
@@ -47,7 +47,7 @@ class RootNormalizer implements Normalizer
     private function normalizeAnnotationTypes(array $annotationTypes)
     {
         return array_map(function ($type) {
-            return $this->typeNormalizer->normalize($type);
+            return $this->normalizers->getNormalizer('type')->normalize($type);
         }, $annotationTypes);
     }
 }

--- a/src/Normalizer/RootNormalizer.php
+++ b/src/Normalizer/RootNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+use function Fesor\RAML\onlyWithinKeys;
+use function Fesor\RAML\excludingKeys;
+
+class RootNormalizer implements Normalizer
+{
+    public function normalize($value)
+    {
+        $resourcesKeys = $this->collectResourceKeys($value);
+        $resources = onlyWithinKeys($value, $resourcesKeys);
+        foreach ($resources as $uri => &$resource) {
+            $resource['uri'] = $uri;
+        }
+
+        $value['resources'] = array_map(function ($resource) {
+            return $this->normalize($resource);
+        }, array_values($resources));
+
+        return excludingKeys($value, $resourcesKeys);
+    }
+
+    private function collectResourceKeys($value)
+    {
+        return array_filter(array_keys($value), function ($key) {
+            return 0 === mb_strpos($key, '/');
+        });
+    }
+}

--- a/src/Normalizer/ScalarValuedNodeNormalizer.php
+++ b/src/Normalizer/ScalarValuedNodeNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class ScalarValuedNodeNormalizer implements Normalizer
+{
+    private static $scalarValuedNodes = [
+        'displayName', 'description', 'type', 'schema', 'default', 'example', 'usage',
+        'repeat', 'required', 'content', 'strict', 'minLength', 'maxLength', 'uniqueItems',
+        'minItems', 'maxItems', 'discriminator', 'minProperties', 'maxProperties',
+        'discriminatorValue', 'pattern', 'format', 'minimum', 'maximum', 'multipleOf',
+        'requestTokenUri', 'authorizationUri', 'tokenCredentialsUri', 'accessTokenUri',
+        'title', 'version', 'baseUri', 'mediaType', 'extends',
+    ];
+
+    private $next;
+
+    public function __construct(Normalizer $next)
+    {
+        $this->next = $next;
+    }
+
+    public function normalize($value)
+    {
+        foreach ($value as $key => $nodeValue) {
+            if (in_array($key, self::$scalarValuedNodes)) {
+                $value[$key] = $this->normalizeNodeValue($nodeValue);
+            }
+        }
+
+        return $this->next->normalize($value);
+    }
+
+    private function normalizeNodeValue($value) {
+
+        if (is_scalar($value)) {
+            return [
+                'value' => $value
+            ];
+        }
+
+        // todo: handle errors?
+        if (!isset($value['value'])) {
+            $value['value'] = null;
+        }
+
+        return $value;
+    }
+}

--- a/src/Normalizer/TypeNormalizer.php
+++ b/src/Normalizer/TypeNormalizer.php
@@ -14,8 +14,20 @@ class TypeNormalizer
         if ($value['type'] === 'object' && isset($value['properties'])) {
             $value['properties'] = $this->expandProperties($value['properties']);
         }
+        if ($value['type'] === 'array' && isset($value['items'])) {
+            $value['items'] = $this->expandItems($value['items']);
+        }
 
         return $value;
+    }
+
+    private function expandItems($items)
+    {
+        if (!is_array($items)) {
+            return $items;
+        }
+
+        return $this->normalize($items);
     }
 
     private function expandProperties(array $properties)

--- a/src/Normalizer/TypeNormalizer.php
+++ b/src/Normalizer/TypeNormalizer.php
@@ -31,6 +31,9 @@ class TypeNormalizer implements Normalizer
                 $expandedValue['items'] = $this->expandTypeExpression($value['items']);
             }
         }
+        if (isset($value['facets'])) {
+            $expandedValue['facets'] = $this->normalizeProperties($value['facets']);
+        }
 
         return array_filter($expandedValue, function ($value) {
             return null !== $value;

--- a/src/Normalizer/TypeNormalizer.php
+++ b/src/Normalizer/TypeNormalizer.php
@@ -2,6 +2,8 @@
 
 namespace Fesor\RAML\Normalizer;
 
+use function Fesor\RAML\onlyWithinKeys;
+
 class TypeNormalizer implements Normalizer
 {
 
@@ -62,9 +64,11 @@ class TypeNormalizer implements Normalizer
 
     private function filterPatternProperties(array $properties, $excludePatternProperties = false)
     {
-        return array_filter($properties, function ($key) use ($excludePatternProperties) {
+        $keys = array_filter(array_keys($properties), function ($key) use ($excludePatternProperties) {
             return $excludePatternProperties ^ (!!preg_match('/^\/.*\/$/', $key));
-        }, ARRAY_FILTER_USE_KEY);
+        });
+
+        return onlyWithinKeys($properties, $keys);
     }
 
     private function expandProperties(array $properties)

--- a/src/Normalizer/TypeNormalizer.php
+++ b/src/Normalizer/TypeNormalizer.php
@@ -9,6 +9,10 @@ class TypeNormalizer implements Normalizer
 
     public function normalize($value)
     {
+        if (!is_array($value)) {
+            $value = ['type' => $value];
+        }
+        
         $type = $value['type'] = $this->guessType($value);
 
         if ($this->isUserDefinedTypeOrExpression($value['type'])) {

--- a/src/Normalizer/TypeNormalizer.php
+++ b/src/Normalizer/TypeNormalizer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Fesor\RAML\Normalizer;
+
+class TypeNormalizer
+{
+    public function normalize($value)
+    {
+        $value['type'] = $this->guessType($value);
+        $value = array_merge(
+            $value,
+            $this->expandShortArrayTypeDeclaration($value['type'])
+        );
+        if ($value['type'] === 'object' && isset($value['properties'])) {
+            $value['properties'] = $this->expandProperties($value['properties']);
+        }
+
+        return $value;
+    }
+
+    private function expandProperties(array $properties)
+    {
+        foreach ($properties as $prop => $definition) {
+            if (is_string($definition)) {
+                $properties[$prop] = ['type' => $definition];
+            }
+
+            $properties[$prop] = $this->normalize($properties[$prop]);
+
+            if (array_key_exists('required', $properties[$prop]) && $properties[$prop]['required']) {
+                continue;
+            }
+
+            if (mb_substr($prop, -1) === '?') {
+                $expandedProp = mb_substr($prop, 0, -1);
+                $properties[$expandedProp] = $properties[$prop];
+                $properties[$expandedProp]['required'] = false;
+                unset($properties[$prop]);
+            }
+        }
+
+        return $properties;
+    }
+
+    private function expandShortArrayTypeDeclaration($type)
+    {
+        if (mb_substr($type, -2) === '[]') {
+            return [
+                'type' => 'array',
+                'items' => mb_substr($type, 0, -2)
+            ];
+        }
+
+        return [];
+    }
+
+    private function guessType($value)
+    {
+        if (isset($value['type'])) {
+            return $value['type'];
+        }
+
+        $typesForProperties = [
+            'properties' => 'object',
+            'items' => 'array'
+        ];
+
+        foreach ($typesForProperties as $prop => $type) {
+            if (isset($value[$prop])) {
+                return $type;
+            }
+        }
+
+        return 'string';
+    }
+
+    private function getKnowPropertiesForType($type)
+    {
+        $base = ['default', 'type', 'example', 'examples', 'displayName', 'description', 'facets', 'xml'];
+        $byTypes = [
+            'object' => [
+                'properties', 'minProperties', 'maxProperties', 'additionalProperties',
+                'discriminator', 'discriminatorValue'
+            ],
+            'scalar' => ['enum'],
+            'string' => ['pattern', 'minLength', 'maxLength'],
+            'file' => ['fileTypes', 'minLength', 'maxLength'],
+            'number' => ['minimum', 'maximum', 'format', 'multipleOf'],
+            'array' => ['uniqueItems', 'items', 'minItems', 'maxItems'],
+            'datetime' => ['format']
+        ];
+        $byTypes['integer'] = $byTypes['number'];
+    }
+
+    private function getTypeChain()
+    {
+
+    }
+}

--- a/src/RAMLLoader.php
+++ b/src/RAMLLoader.php
@@ -6,7 +6,7 @@ interface RAMLLoader
 {
     /**
      * @param string $url
-     * @return array
+     * @return RAML
      */
     public function load($url);
 }

--- a/src/RAMLLoader.php
+++ b/src/RAMLLoader.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Fesor\RAML;
+
+interface RAMLLoader
+{
+    /**
+     * @param string $url
+     * @return array
+     */
+    public function load($url);
+}

--- a/src/Raml.php
+++ b/src/Raml.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Fesor\RAML;
+
+class Raml
+{
+    private $data;
+
+    private function __construct(array $data)
+    {
+        $this->data = array_replace([
+            'title' => '',
+            'description' => '',
+            'version' => null,
+            'resources' => [],
+            'baseUri' => '',
+        ], $data);
+
+        $this->data['resources'] = Resource::collectionFromArray($this->data['resources']);
+    }
+
+    public static function fromArray($data)
+    {
+        return new Raml($data);
+    }
+
+    public function getTitle()
+    {
+        return $this->data['title'];
+    }
+
+    public function getDescription()
+    {
+        return $this->data['description'];
+    }
+
+    public function getVersion()
+    {
+        return $this->data['version'];
+    }
+
+    public function getBaseUri()
+    {
+        return $this->data['baseUri'];
+    }
+
+    public function getAllResources()
+    {
+        $collection = [];
+        $this->collectResources($collection, $this->data['resources']);
+
+        return $collection;
+    }
+
+    private function collectResources(array &$collection, array $resources)
+    {
+        foreach ($resources as $resource) {
+            $collection[] = $resource;
+            $this->collectResources($collection, $resource->getSubResources(), $resources);
+        }
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Fesor\RAML;
+
+class Resource
+{
+    private $data;
+
+    private $parent;
+
+    private function __construct(array $data, Resource $parent = null)
+    {
+        $this->parent = $parent;
+        $this->data = array_replace([
+            'description' => '',
+            'resources' => []
+        ], $data);
+
+        $this->data['resources'] = static::collectionFromArray($this->data['resources'], $this);
+    }
+
+    public static function fromArray(array $data, Resource $parent = null)
+    {
+        return new Resource($data, $parent);
+    }
+
+    public static function collectionFromArray(array $collection, Resource $parent = null)
+    {
+        return array_map(function (array $resource) use ($parent) {
+            return static::fromArray($resource, $parent);
+        }, $collection);
+    }
+
+    public function getDisplayName()
+    {
+        return empty($this->data['displayName']) ?
+            $this->data['uri'] : $this->data['displayName'];
+    }
+
+    public function getDescription()
+    {
+        return $this->data['description'];
+    }
+
+    public function getUri()
+    {
+        return $this->data['uri'];
+    }
+
+    public function getAbsoluteUri()
+    {
+        $chunks = [];
+        $resource = $this;
+        do {
+            $chunks[] = $resource->getUri();
+        } while ($resource = $resource->parent);
+
+        return implode(array_reverse($chunks));
+    }
+
+    public function getSubResources()
+    {
+        return $this->data['resources'];
+    }
+}

--- a/src/Type/NumberType.php
+++ b/src/Type/NumberType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+use function Fesor\RAML\withDefaultValues;
+
+class NumberType extends ScalarType
+{
+    private static $supportedFormats = ['int64', 'int64', 'int', 'long', 'float', 'double', 'int16', 'int8'];
+
+    private $data;
+
+    public function __construct($name, array $data, $parentType = null)
+    {
+        $this->data = withDefaultValues([
+            'minimum' => null,
+            'maximum' => null,
+            'format' => null,
+            'multipleOf' => null
+        ], $data);
+
+        if (
+            null !== $this->data['format']
+            && !in_array($this->data['format'], self::$supportedFormats)
+        ) {
+            throw new \RuntimeException(sprintf(
+                'Unsupported format "%s" for numeric value',
+                $this->data['format']
+            ));
+        }
+
+        parent::__construct($name, $data, $parentType);
+    }
+
+
+    public function getMinimum()
+    {
+        return $this->data['minimum'];
+    }
+
+    public function getMaxium()
+    {
+        return $this->data['maximum'];
+    }
+
+    public function getFormat()
+    {
+        return $this->data['format'];
+    }
+
+    public function getMultipleOf()
+    {
+        return $this->data['multipleOf'];
+    }
+}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+class ObjectType extends Type
+{
+    public function __construct($name, array $data, $parentType = null)
+    {
+        parent::__construct($name, $data, $parentType);
+    }
+}

--- a/src/Type/ScalarType.php
+++ b/src/Type/ScalarType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+use function Fesor\RAML\withDefaultValues;
+
+class ScalarType extends Type
+{
+    private $data;
+
+    public function __construct($name, array $data, $parentType = null)
+    {
+        $this->data = withDefaultValues([
+            'enum' => []
+        ], $data);
+
+        parent::__construct($name, $data, $parentType);
+    }
+
+    public function getEnum()
+    {
+        return $this->data['enum'];
+    }
+}

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+use function Fesor\RAML\withDefaultValues;
+
+class StringType extends ScalarType
+{
+    private $data;
+
+    public function __construct($name, array $data, Type $parentType = null)
+    {
+        $this->data = withDefaultValues([
+            'pattern' => null,
+            'minLength' => 0,
+            'maxLength' => 2147483647
+        ], $data);
+
+        parent::__construct($name, $data, $parentType);
+    }
+
+    public function getPattern()
+    {
+        return $this->data['pattern'];
+    }
+
+    public function getMinLength()
+    {
+        return $this->data['minLength'];
+    }
+
+    public function getMaxLength()
+    {
+        return $this->data['maxLength'];
+    }
+}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+use function Fesor\RAML\withDefaultValues;
+
+abstract class Type
+{
+    private $name;
+
+    private $data;
+
+    protected $parentType;
+
+    /**
+     * Type constructor.
+     * @param string $name
+     * @param array $data
+     * @param Type|null $parentType
+     */
+    protected function __construct($name, array $data, Type $parentType = null)
+    {
+        $this->data = withDefaultValues([
+            'type' => 'string',
+            'example' => null,
+            'examples' => [],
+            'displayName' => $name,
+            'description' => '',
+            'annotations' => [],
+            'facets' => []
+        ], $data);
+
+        $this->parentType = $parentType;
+    }
+
+    public function getDisplayName()
+    {
+        return $this->data['displayName'];
+    }
+
+    public function getDescription()
+    {
+        return $this->data['description'];
+    }
+
+    public function getExample()
+    {
+        return $this->data['example'];
+    }
+
+    public function getExamples()
+    {
+        return $this->data['examples'];
+    }
+
+    public function getBaseType()
+    {
+        return $this->parentType;
+    }
+
+    public function getUserDefinedFacets()
+    {
+        return $this->data['facets'];
+    }
+
+    public function getAnnotations()
+    {
+        return $this->data['annotations'];
+    }
+}

--- a/src/Type/TypeRegistry.php
+++ b/src/Type/TypeRegistry.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Fesor\RAML\Type;
+
+class TypeRegistry
+{
+    private $types = [];
+
+    private static $typeDefinitionClassMap = [
+        'string' => StringType::class,
+        'number' => NumberType::class,
+        'boolean' => ScalarType::class,
+        'null' => ScalarType::class,
+        'object' => ObjectType::class
+    ];
+
+    public function __construct()
+    {
+        $this->register('integer', [
+            'type' => 'number',
+            'multipleOf' => 1
+        ]);
+    }
+
+    public function register($name, $typeDefinition = null)
+    {
+        if (!$typeDefinition instanceof Type) {
+            $typeDefinition = $this->createTypeFromDefinition($name, $typeDefinition);
+        }
+
+        $this->types[$name] = $typeDefinition;
+    }
+
+    /**
+     * @param $name
+     * @return Type
+     */
+    public function resolve($name)
+    {
+        if (array_key_exists($name, $this->types)) {
+            return $this->types[$name];
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Unable to resolve type "%s"', $name
+        ));
+    }
+
+    private function createTypeFromDefinition($name, array $typeDefinition)
+    {
+        if (!isset($typeDefinition['type']) && isset($typeDefinition['oneOf'])) {
+            // todo: union types
+            throw new \RuntimeException('Union types are not implemented');
+        }
+
+        if (!isset($typeDefinition['type'])) {
+            throw new \RuntimeException('Unable to register unknown type');
+        }
+
+        $parent = null;
+        if (!isset(self::$typeDefinitionClassMap[$typeDefinition['type']])) {
+            $parent = $this->resolve($typeDefinition['type']);
+            $className = get_class($parent);
+        } else {
+            $className = self::$typeDefinitionClassMap[$typeDefinition['type']];
+        }
+
+        return new $className($name, $typeDefinition, $parent);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,3 +2,12 @@
 
 namespace Fesor\RAML;
 
+function onlyWithinKeys(array $data, array $keys)
+{
+    return array_intersect_key($data, array_flip($keys));
+}
+
+function excludingKeys(array $data, array $keys)
+{
+    return array_diff_key($data, array_flip($keys));
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -12,6 +12,14 @@ function excludingKeys(array $data, array $keys)
     return array_diff_key($data, array_flip($keys));
 }
 
+function withDefaultValues(array $defaults, array $data)
+{
+    return array_intersect_key(
+        array_replace($defaults, $data),
+        $defaults
+    );
+}
+
 /**
  * Naive media type validator.
  *

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,3 +11,17 @@ function excludingKeys(array $data, array $keys)
 {
     return array_diff_key($data, array_flip($keys));
 }
+
+/**
+ * Naive media type validator.
+ *
+ * Not sure does it covers all use cases
+ * that covered in RFC 6838
+ *
+ * @param string $mediaType
+ * @return boolean
+ */
+function isValidMediaType($mediaType)
+{
+    return !!preg_match('/^\w+\/[-+.\w]+$/', $mediaType);
+}

--- a/tests/spec/MethodSpec.php
+++ b/tests/spec/MethodSpec.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace spec\Fesor\RAML;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MethodSpec extends ObjectBehavior
+{
+    
+}

--- a/tests/spec/Normalizer/AnnotationsNormalizerSpec.php
+++ b/tests/spec/Normalizer/AnnotationsNormalizerSpec.php
@@ -21,12 +21,9 @@ class AnnotationsNormalizerSpec extends ObjectBehavior
             'value' => 'test',
             '(annotation1)' => 'value1',
             '(annotation2)' => 'value2'
-        ])->shouldBeLike([
-            'value' => 'test',
-            'annotations' => [
-                'annotation1' => 'value1',
-                'annotation2' => 'value2'
-            ]
-        ]);
+        ])->shouldBeArray([
+            'annotation1' => 'value1',
+            'annotation2' => 'value2'
+        ], ['at' => 'annotations']);
     }
 }

--- a/tests/spec/Normalizer/AnnotationsNormalizerSpec.php
+++ b/tests/spec/Normalizer/AnnotationsNormalizerSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use Fesor\RAML\Normalizer\Normalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AnnotationsNormalizerSpec extends ObjectBehavior
+{
+
+    function let(Normalizer $normalizer)
+    {
+        $this->beConstructedWith($normalizer);
+        $normalizer->normalize(Argument::any())->willReturnArgument(0)->shouldBeCalled();
+    }
+
+    function it_collects_annotations()
+    {
+        $this->normalize([
+            'value' => 'test',
+            '(annotation1)' => 'value1',
+            '(annotation2)' => 'value2'
+        ])->shouldBeLike([
+            'value' => 'test',
+            'annotations' => [
+                'annotation1' => 'value1',
+                'annotation2' => 'value2'
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Normalizer/ImportNormalizerSpec.php
+++ b/tests/spec/Normalizer/ImportNormalizerSpec.php
@@ -17,11 +17,9 @@ class ImportNormalizerSpec extends ObjectBehavior
     {
         $loader->load('myTypes.raml')->willReturn('imported')->shouldBeCalled();
 
-        $this->normalize([
-            'types' => '!include myTypes.raml'
-        ])->shouldBeLike([
-            'types' => 'imported'
-        ]);
+        $this
+            ->normalize(['types' => '!include myTypes.raml'])
+            ->shouldBeLike(['types' => 'imported']);
     }
 
     function xit_collects_all_imports_recursivly(RAMLLoader $loader)
@@ -30,19 +28,11 @@ class ImportNormalizerSpec extends ObjectBehavior
         $loader->load('b.raml')->willReturn('b')->shouldBeCalled();
 
         $this->normalize([
-            'foo' => [
-                'a' => '!include a.raml'
-            ],
-            'bar' => [
-                'b' => '!include b.raml'
-            ]
+            'foo' => ['a' => '!include a.raml'],
+            'bar' => ['b' => '!include b.raml']
         ])->shouldBeLike([
-            'foo' => [
-                'a' => 'a'
-            ],
-            'bar' => [
-                'b' => 'b'
-            ]
+            'foo' => ['a' => 'a'],
+            'bar' => ['b' => 'b']
         ]);
     }
 }

--- a/tests/spec/Normalizer/ImportNormalizerSpec.php
+++ b/tests/spec/Normalizer/ImportNormalizerSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use Fesor\RAML\RAMLLoader;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ImportNormalizerSpec extends ObjectBehavior
+{
+    function let(RAMLLoader $loader)
+    {
+        $this->beConstructedWith($loader);
+    }
+
+    function it_supports_import_tag(RAMLLoader $loader)
+    {
+        $loader->load('myTypes.raml')->willReturn('imported')->shouldBeCalled();
+
+        $this->normalize([
+            'types' => '!include myTypes.raml'
+        ])->shouldBeLike([
+            'types' => 'imported'
+        ]);
+    }
+
+    function xit_collects_all_imports_recursivly(RAMLLoader $loader)
+    {
+        $loader->load('a.raml')->willReturn('a')->shouldBeCalled();
+        $loader->load('b.raml')->willReturn('b')->shouldBeCalled();
+
+        $this->normalize([
+            'foo' => [
+                'a' => '!include a.raml'
+            ],
+            'bar' => [
+                'b' => '!include b.raml'
+            ]
+        ])->shouldBeLike([
+            'foo' => [
+                'a' => 'a'
+            ],
+            'bar' => [
+                'b' => 'b'
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Normalizer/MethodNormalizerSpec.php
+++ b/tests/spec/Normalizer/MethodNormalizerSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MethodNormalizerSpec extends ObjectBehavior
+{
+    function it_collects_methods()
+    {
+        $this->normalize([
+            'test' => 'test',
+            'post' => [],
+            'get' => []
+        ])->shouldBeLike([
+            'test' => 'test',
+            'methods' => [
+                ['method' => 'post'],
+                ['method' => 'get']
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Normalizer/MethodNormalizerSpec.php
+++ b/tests/spec/Normalizer/MethodNormalizerSpec.php
@@ -2,10 +2,119 @@
 
 namespace spec\Fesor\RAML\Normalizer;
 
+use Fesor\RAML\Normalizer\Normalizer;
+use Fesor\RAML\Normalizer\NormalizerRegistry;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class MethodNormalizerSpec extends ObjectBehavior
 {
-    
+    function let(NormalizerRegistry $normalizerRegistry, Normalizer $typeNormalizer, Normalizer $propertiesNormalizer)
+    {
+        $normalizerRegistry->getNormalizer('properties')->willReturn($propertiesNormalizer);
+        $normalizerRegistry->getNormalizer('type')->willReturn($typeNormalizer);
+
+        $this->beConstructedWith($normalizerRegistry);
+    }
+
+    function it_normalizes_headers(Normalizer $propertiesNormalizer)
+    {
+        $this->shouldNormalizesTypes($propertiesNormalizer);
+
+        $this->normalize([
+            'headers' => [
+                'X-Authorization' => [
+                    'pattern' => '^Bearer .+'
+                ],
+                'X-Other-Header?' => 'string',
+            ]
+        ]);
+    }
+
+    function it_normalizes_request_bodies(Normalizer $typeNormalizer)
+    {
+        $this->shouldNormalizesTypes($typeNormalizer);
+
+        $this->normalize([
+            'body' => [
+                'application/json' => 'Post',
+                'application/xml' => 'PostXml'
+            ]
+        ]);
+    }
+
+    function it_supports_in_place_type_declaration_as_body(Normalizer $typeNormalizer)
+    {
+        $this->shouldNormalizesTypes($typeNormalizer);
+
+        $this->normalize([
+            'body' => [
+                'properties' => []
+            ]
+        ])->shouldBeArray([
+            'normalized' => true
+        ], ['at' => 'body']);
+    }
+
+    function it_supports_type_expressions_as_body_declaration(Normalizer $typeNormalizer)
+    {
+        $this->shouldNormalizesTypes($typeNormalizer);
+
+        $this->normalize([
+            'body' => 'BasicPost | ExtendedPost'
+        ]);
+    }
+
+    function it_normalizes_responses()
+    {
+        $this->normalize([
+            'responses' => [
+                '200' => []
+            ]
+        ])->shouldBeArray([
+            [
+                'statusCode' => 200,
+                'headers' => []
+            ]
+        ], ['at' => 'responses']);
+    }
+
+    function it_normalizes_response_headers(Normalizer $propertiesNormalizer)
+    {
+        $this->shouldNormalizesTypes($propertiesNormalizer);
+
+        $this->normalize([
+            'responses' => [
+                '200' => [
+                    'headers' => [
+                        'X-Header?' => 'string'
+                    ]
+                ]
+            ]
+        ])->shouldBeArray(
+            ['normalized' => true],
+            ['at' => 'responses/0/headers']
+        );
+    }
+
+    function it_normalizes_response_bodies(Normalizer $typeNormalizer)
+    {
+        $this->shouldNormalizesTypes($typeNormalizer);
+
+        $this->normalize([
+            'responses' => [
+                '200' => [
+                    'body' => 'Post'
+                ]
+            ]
+        ])->shouldBeArray(
+            ['normalized' => true],
+            ['at' => 'responses/0/body']
+        );
+    }
+
+    private function shouldNormalizesTypes($normalizer)
+    {
+        $normalizer->normalize(Argument::any())->willReturn(['normalized' => true])->shouldBeCalled();
+    }
 }

--- a/tests/spec/Normalizer/MethodNormalizerSpec.php
+++ b/tests/spec/Normalizer/MethodNormalizerSpec.php
@@ -7,18 +7,5 @@ use Prophecy\Argument;
 
 class MethodNormalizerSpec extends ObjectBehavior
 {
-    function it_collects_methods()
-    {
-        $this->normalize([
-            'test' => 'test',
-            'post' => [],
-            'get' => []
-        ])->shouldBeLike([
-            'test' => 'test',
-            'methods' => [
-                ['method' => 'post'],
-                ['method' => 'get']
-            ]
-        ]);
-    }
+    
 }

--- a/tests/spec/Normalizer/NormalizerRegistrySpec.php
+++ b/tests/spec/Normalizer/NormalizerRegistrySpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use Fesor\RAML\Normalizer\TypeNormalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class NormalizerRegistrySpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->addNormalizer('type', new TypeNormalizer());
+    }
+
+    function it_resolves_normalizer_for_given_name()
+    {
+        $this->shouldNotThrow()->duringGetNormalizer('type');
+        $this->shouldThrow()->duringGetNormalizer('unknown');
+    }
+}

--- a/tests/spec/Normalizer/PropertiesDeclarationNormalizerSpec.php
+++ b/tests/spec/Normalizer/PropertiesDeclarationNormalizerSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use Fesor\RAML\Normalizer\Normalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class PropertiesDeclarationNormalizerSpec extends ObjectBehavior
+{
+    function let(Normalizer $typeNormalizer)
+    {
+        $this->beConstructedWith($typeNormalizer);
+    }
+
+    function it_normalizes_properties_declaration_using_type_normalizer(Normalizer $typeNormalizer)
+    {
+        $this->shouldNormalizesTypes($typeNormalizer);
+
+        $this->normalize([
+            'X-Authorization' => [
+                'pattern' => '^Bearer .+'
+            ],
+            'X-Other-Header?' => 'string',
+        ])
+            ->shouldReturn('normalized');
+    }
+
+    private function shouldNormalizesTypes($normalizer)
+    {
+        $normalizer->normalize(Argument::any())->willReturn([
+            'type' => 'object',
+            'properties' => 'normalized'
+        ])->shouldBeCalled();
+    }
+}

--- a/tests/spec/Normalizer/ResourcesNormalizerSpec.php
+++ b/tests/spec/Normalizer/ResourcesNormalizerSpec.php
@@ -15,8 +15,9 @@ class ResourcesNormalizerSpec extends ObjectBehavior
 
     function it_collects_methods(Normalizer $methodNormalizer)
     {
-        $this->normalizerShouldBeCalledTimes($methodNormalizer, 2);
-        
+        $this->shouldNormalizeMethod($methodNormalizer, 'post');
+        $this->shouldNormalizeMethod($methodNormalizer, 'get');
+
         $this->normalize([
             'uri' => '/users',
             'test' => 'test',
@@ -34,10 +35,8 @@ class ResourcesNormalizerSpec extends ObjectBehavior
         ]);
     }
 
-    private function normalizerShouldBeCalledTimes($methodNormalizer, $n)
+    private function shouldNormalizeMethod($methodNormalizer, $method)
     {
-        $methodNormalizer->normalize(Argument::that(function ($arg) {
-            return isset($arg['method']);
-        }))->willReturn(['method'])->shouldBeCalledTimes($n);
+        $methodNormalizer->normalize(compact('method'))->willReturn(['method'])->shouldBeCalled();
     }
 }

--- a/tests/spec/Normalizer/ResourcesNormalizerSpec.php
+++ b/tests/spec/Normalizer/ResourcesNormalizerSpec.php
@@ -7,49 +7,23 @@ use Prophecy\Argument;
 
 class ResourcesNormalizerSpec extends ObjectBehavior
 {
-    function it_collects_resource_definitions()
-    {
-        $this->normalize([
-            'title' => 'API',
-            '/' => [],
-            '/users' => ['description' => '']
-        ])->shouldBeLike([
-            'title' => 'API',
-            'resources' => [
-                [
-                    'uri' => '/',
-                    'resources' => []
-                ],
-                [
-                    'uri' => '/users',
-                    'description' => '',
-                    'resources' => []
-                ]
-            ]
-        ]);
-    }
 
-    function it_normalizes_nested_resource_definitions()
+    function it_collects_methods()
     {
         $this->normalize([
-            '/users' => [
-                '/{id}' => [
-                    'description' => 'user details'
-                ]
-            ]
+            'uri' => '/users',
+            'test' => 'test',
+            'post' => [],
+            'get' => [],
+            'resources' => []
         ])->shouldBeLike([
-            'resources' => [
-                [
-                    'uri' => '/users',
-                    'resources' => [
-                        [
-                            'description' => 'user details',
-                            'uri' => '/{id}',
-                            'resources' => []
-                        ]
-                    ]
-                ],
-            ]
+            'uri' => '/users',
+            'test' => 'test',
+            'resources' => [],
+            'methods' => [
+                ['method' => 'post'],
+                ['method' => 'get']
+            ],
         ]);
     }
 }

--- a/tests/spec/Normalizer/ResourcesNormalizerSpec.php
+++ b/tests/spec/Normalizer/ResourcesNormalizerSpec.php
@@ -2,14 +2,21 @@
 
 namespace spec\Fesor\RAML\Normalizer;
 
+use Fesor\RAML\Normalizer\Normalizer;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class ResourcesNormalizerSpec extends ObjectBehavior
 {
-
-    function it_collects_methods()
+    function let(Normalizer $methodNormalizer)
     {
+        $this->beConstructedWith($methodNormalizer);
+    }
+
+    function it_collects_methods(Normalizer $methodNormalizer)
+    {
+        $this->normalizerShouldBeCalledTimes($methodNormalizer, 2);
+        
         $this->normalize([
             'uri' => '/users',
             'test' => 'test',
@@ -21,9 +28,16 @@ class ResourcesNormalizerSpec extends ObjectBehavior
             'test' => 'test',
             'resources' => [],
             'methods' => [
-                ['method' => 'post'],
-                ['method' => 'get']
+                ['method'],
+                ['method']
             ],
         ]);
+    }
+
+    private function normalizerShouldBeCalledTimes($methodNormalizer, $n)
+    {
+        $methodNormalizer->normalize(Argument::that(function ($arg) {
+            return isset($arg['method']);
+        }))->willReturn(['method'])->shouldBeCalledTimes($n);
     }
 }

--- a/tests/spec/Normalizer/ResourcesNormalizerSpec.php
+++ b/tests/spec/Normalizer/ResourcesNormalizerSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ResourcesNormalizerSpec extends ObjectBehavior
+{
+    function it_collects_resource_definitions()
+    {
+        $this->normalize([
+            'title' => 'API',
+            '/' => [],
+            '/users' => ['description' => '']
+        ])->shouldBeLike([
+            'title' => 'API',
+            'resources' => [
+                [
+                    'uri' => '/',
+                    'resources' => []
+                ],
+                [
+                    'uri' => '/users',
+                    'description' => '',
+                    'resources' => []
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_nested_resource_definitions()
+    {
+        $this->normalize([
+            '/users' => [
+                '/{id}' => [
+                    'description' => 'user details'
+                ]
+            ]
+        ])->shouldBeLike([
+            'resources' => [
+                [
+                    'uri' => '/users',
+                    'resources' => [
+                        [
+                            'description' => 'user details',
+                            'uri' => '/{id}',
+                            'resources' => []
+                        ]
+                    ]
+                ],
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Normalizer/RootNormalizerSpec.php
+++ b/tests/spec/Normalizer/RootNormalizerSpec.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RootNormalizerSpec extends ObjectBehavior
+{
+    
+}

--- a/tests/spec/Normalizer/RootNormalizerSpec.php
+++ b/tests/spec/Normalizer/RootNormalizerSpec.php
@@ -20,20 +20,17 @@ class RootNormalizerSpec extends ObjectBehavior
             'title' => 'API',
             '/' => [],
             '/users' => ['description' => '']
-        ])->shouldBeLike([
-            'title' => 'API',
-            'resources' => [
-                [
-                    'uri' => '/',
-                    'resources' => []
-                ],
-                [
-                    'uri' => '/users',
-                    'description' => '',
-                    'resources' => []
-                ]
+        ])->shouldBeArray([
+            [
+                'uri' => '/',
+                'resources' => []
+            ],
+            [
+                'uri' => '/users',
+                'description' => '',
+                'resources' => []
             ]
-        ]);
+        ], ['at' => 'resources']);
     }
 
     function it_normalizes_nested_resource_definitions()
@@ -44,20 +41,16 @@ class RootNormalizerSpec extends ObjectBehavior
                     'description' => 'user details'
                 ]
             ]
-        ])->shouldBeLike([
+        ])->shouldBeArray([
+            'uri' => '/users',
             'resources' => [
                 [
-                    'uri' => '/users',
-                    'resources' => [
-                        [
-                            'description' => 'user details',
-                            'uri' => '/{id}',
-                            'resources' => []
-                        ]
-                    ]
-                ],
+                    'description' => 'user details',
+                    'uri' => '/{id}',
+                    'resources' => []
+                ]
             ]
-        ]);
+        ], ['at' => 'resources/0']);
     }
 
     function it_normalizes_annotation_types_using_type_normalizer(Normalizer $typeNormalizer)
@@ -84,14 +77,11 @@ class RootNormalizerSpec extends ObjectBehavior
                     ]
                 ]
             ]
-        ])->shouldBeLike([
-            'resources' => [],
-            'annotationTypes' => [
-                'experimental' => 'tested',
-                'badge' => 'tested',
-                'clearanceLevel' => 'tested'
-            ],
-        ]);
+        ])->shouldBeArray([
+            'experimental' => 'tested',
+            'badge' => 'tested',
+            'clearanceLevel' => 'tested'
+        ], ['at' => 'annotationTypes']);
     }
 
     private function shouldNormalizeTypes($typeNormalizer, ...$types)

--- a/tests/spec/Normalizer/RootNormalizerSpec.php
+++ b/tests/spec/Normalizer/RootNormalizerSpec.php
@@ -3,15 +3,16 @@
 namespace spec\Fesor\RAML\Normalizer;
 
 use Fesor\RAML\Normalizer\Normalizer;
+use Fesor\RAML\Normalizer\NormalizerRegistry;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class RootNormalizerSpec extends ObjectBehavior
 {
 
-    function let(Normalizer $typeNormalizer)
+    function let(NormalizerRegistry $normalizers)
     {
-        $this->beConstructedWith($typeNormalizer);
+        $this->beConstructedWith($normalizers);
     }
 
     function it_collects_resources()
@@ -53,9 +54,10 @@ class RootNormalizerSpec extends ObjectBehavior
         ], ['at' => 'resources/0']);
     }
 
-    function it_normalizes_annotation_types_using_type_normalizer(Normalizer $typeNormalizer)
+    function it_normalizes_annotation_types_using_type_normalizer(NormalizerRegistry $normalizers, Normalizer $typeNormalizer)
     {
 
+        $this->shouldAskForNormalizer($normalizers, $typeNormalizer, 'type');
         $this->shouldNormalizeTypes($typeNormalizer, 'null | string', null, [
                 'properties' => [
                     'level' => [
@@ -82,6 +84,11 @@ class RootNormalizerSpec extends ObjectBehavior
             'badge' => 'tested',
             'clearanceLevel' => 'tested'
         ], ['at' => 'annotationTypes']);
+    }
+
+    private function shouldAskForNormalizer($normalizers, $normalizer, $name)
+    {
+        $normalizers->getNormalizer($name)->willReturn($normalizer)->shouldBeCalled();
     }
 
     private function shouldNormalizeTypes($typeNormalizer, ...$types)

--- a/tests/spec/Normalizer/RootNormalizerSpec.php
+++ b/tests/spec/Normalizer/RootNormalizerSpec.php
@@ -7,5 +7,49 @@ use Prophecy\Argument;
 
 class RootNormalizerSpec extends ObjectBehavior
 {
-    
+    function it_collects_resources()
+    {
+        $this->normalize([
+            'title' => 'API',
+            '/' => [],
+            '/users' => ['description' => '']
+        ])->shouldBeLike([
+            'title' => 'API',
+            'resources' => [
+                [
+                    'uri' => '/',
+                    'resources' => []
+                ],
+                [
+                    'uri' => '/users',
+                    'description' => '',
+                    'resources' => []
+                ]
+            ]
+        ]);
+    }
+
+    function it_normalizes_nested_resource_definitions()
+    {
+        $this->normalize([
+            '/users' => [
+                '/{id}' => [
+                    'description' => 'user details'
+                ]
+            ]
+        ])->shouldBeLike([
+            'resources' => [
+                [
+                    'uri' => '/users',
+                    'resources' => [
+                        [
+                            'description' => 'user details',
+                            'uri' => '/{id}',
+                            'resources' => []
+                        ]
+                    ]
+                ],
+            ]
+        ]);
+    }
 }

--- a/tests/spec/Normalizer/RootNormalizerSpec.php
+++ b/tests/spec/Normalizer/RootNormalizerSpec.php
@@ -2,11 +2,18 @@
 
 namespace spec\Fesor\RAML\Normalizer;
 
+use Fesor\RAML\Normalizer\Normalizer;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class RootNormalizerSpec extends ObjectBehavior
 {
+
+    function let(Normalizer $typeNormalizer)
+    {
+        $this->beConstructedWith($typeNormalizer);
+    }
+
     function it_collects_resources()
     {
         $this->normalize([
@@ -51,5 +58,48 @@ class RootNormalizerSpec extends ObjectBehavior
                 ],
             ]
         ]);
+    }
+
+    function it_normalizes_annotation_types_using_type_normalizer(Normalizer $typeNormalizer)
+    {
+
+        $this->shouldNormalizeTypes($typeNormalizer, 'null | string', null, [
+                'properties' => [
+                    'level' => [
+                        'enum' => ['low', 'medium', 'high']
+                    ]
+                ]
+            ]
+        );
+
+        $this->normalize([
+            'annotationTypes' => [
+                'experimental' => 'null | string',
+                'badge' => null,
+                'clearanceLevel' => [
+                    'properties' => [
+                        'level' => [
+                            'enum' => ['low', 'medium', 'high']
+                        ]
+                    ]
+                ]
+            ]
+        ])->shouldBeLike([
+            'resources' => [],
+            'annotationTypes' => [
+                'experimental' => 'tested',
+                'badge' => 'tested',
+                'clearanceLevel' => 'tested'
+            ],
+        ]);
+    }
+
+    private function shouldNormalizeTypes($typeNormalizer, ...$types)
+    {
+        foreach ($types as $type) {
+            $typeNormalizer->normalize(Argument::exact($type))
+                ->willReturn('tested')
+                ->shouldBeCalled();
+        }
     }
 }

--- a/tests/spec/Normalizer/ScalarValuedNodeNormalizerSpec.php
+++ b/tests/spec/Normalizer/ScalarValuedNodeNormalizerSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use Fesor\RAML\Normalizer\Normalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ScalarValuedNodeNormalizerSpec extends ObjectBehavior
+{
+    function let(Normalizer $next)
+    {
+        $this->beConstructedWith($next);
+        $next->normalize(Argument::any())->willReturnArgument(0);
+    }
+
+    function it_normalizes_scalar_valued_nodes()
+    {
+        $scalarValuedNodes = [
+            'displayName',
+            'description',
+            'type',
+            'schema',
+            'default',
+            'example',
+            'usage',
+            'repeat',
+            'required',
+            'content',
+            'strict',
+            'minLength',
+            'maxLength',
+            'uniqueItems',
+            'minItems',
+            'maxItems',
+            'discriminator',
+            'minProperties',
+            'maxProperties',
+            'discriminatorValue',
+            'pattern',
+            'format',
+            'minimum',
+            'maximum',
+            'multipleOf',
+            'requestTokenUri',
+            'authorizationUri',
+            'tokenCredentialsUri',
+            'accessTokenUri',
+            'title',
+            'version',
+            'baseUri',
+            'mediaType',
+            'extends',
+        ];
+
+        foreach ($scalarValuedNodes as $scalarValuedNode) {
+            $this->normalize([
+                $scalarValuedNode => 'scalar value'
+            ])->shouldBeLike([
+                $scalarValuedNode => [
+                    'value' => 'scalar value'
+                ]
+            ]);
+        }
+    }
+
+    function it_normalize_object_value()
+    {
+        $this->normalize([
+            'title' => [
+                '(annotation)' => 'value'
+            ]
+        ])->shouldBeLike([
+            'title' => [
+                'value' => null,
+                '(annotation)' => 'value'
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Normalizer/ScalarValuedNodeNormalizerSpec.php
+++ b/tests/spec/Normalizer/ScalarValuedNodeNormalizerSpec.php
@@ -70,11 +70,9 @@ class ScalarValuedNodeNormalizerSpec extends ObjectBehavior
             'title' => [
                 '(annotation)' => 'value'
             ]
-        ])->shouldBeLike([
-            'title' => [
-                'value' => null,
-                '(annotation)' => 'value'
-            ]
-        ]);
+        ])->shouldContainSubset([
+            'value' => null,
+            '(annotation)' => 'value'
+        ], ['at' => 'title']);
     }
 }

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -10,7 +10,7 @@ class TypeNormalizerSpec extends ObjectBehavior
 
     function it_uses_string_as_default_type()
     {
-        $this->normalize([])->shouldReturnSubset([
+        $this->normalize([])->shouldContainSubset([
             'type' => 'string',
         ]);
     }
@@ -18,7 +18,7 @@ class TypeNormalizerSpec extends ObjectBehavior
     function it_guest_type_as_array_it_items_present()
     {
         $this->normalize(['items' => 'string'])
-            ->shouldReturnSubset([
+            ->shouldContainSubset([
                 'type' => 'array',
             ]);
     }
@@ -26,7 +26,7 @@ class TypeNormalizerSpec extends ObjectBehavior
     function it_guest_type_as_objet_it_properties_present()
     {
         $this->normalize(['properties' => []])
-            ->shouldReturnSubset([
+            ->shouldContainSubset([
                 'type' => 'object',
             ]);
     }
@@ -34,7 +34,7 @@ class TypeNormalizerSpec extends ObjectBehavior
     function it_supports_type_expressions_for_array_declaration()
     {
         $this->normalize(['type' => 'string[]'])
-            ->shouldReturnSubset([
+            ->shouldContainSubset([
                 'type' => 'array',
                 'items' => ['type' => 'string']
             ]);
@@ -43,7 +43,7 @@ class TypeNormalizerSpec extends ObjectBehavior
     function it_supports_type_expressions_for_union_types()
     {
         $this->normalize(['type' => 'number | string'])
-            ->shouldBeLike([
+            ->shouldContainSubset([
                 'oneOf' => [
                     ['type' => 'string'],
                     ['type' => 'number'],
@@ -54,20 +54,18 @@ class TypeNormalizerSpec extends ObjectBehavior
     function it_supports_complex_type_expressions()
     {
         $this->normalize(['type' => 'boolean | (number | string)[]'])
-            ->shouldReturnSubset([
-                'oneOf' => [
-                    [
-                        'type' => 'array',
-                        'items' => [
-                            'oneOf' => [
-                                ['type' => 'string'],
-                                ['type' => 'number'],
-                            ]
+            ->shouldContainSubset([
+                [
+                    'type' => 'array',
+                    'items' => [
+                        'oneOf' => [
+                            ['type' => 'string'],
+                            ['type' => 'number'],
                         ]
-                    ],
-                    ['type' => 'boolean'],
-                ]
-            ]);
+                    ]
+                ],
+                ['type' => 'boolean'],
+            ], ['at' => 'oneOf']);
     }
 
 
@@ -81,22 +79,20 @@ class TypeNormalizerSpec extends ObjectBehavior
                     'required' => true
                 ]
             ]
-        ])->shouldReturnSubset([
-            'properties' => [
-                'foo' => [
-                    'type' => 'string',
-                    'required' => false
-                ],
-                'bar?' => [
-                    'type' => 'string',
-                    'required' => false
-                ],
-                'buz?' => [
-                    'type' => 'string',
-                    'required' => true
-                ]
+        ])->shouldContainSubset([
+            'foo' => [
+                'type' => 'string',
+                'required' => false
+            ],
+            'bar?' => [
+                'type' => 'string',
+                'required' => false
+            ],
+            'buz?' => [
+                'type' => 'string',
+                'required' => true
             ]
-        ]);
+        ], ['at' => 'properties']);
     }
 
     function it_allow_inplace_type_declaration()
@@ -109,7 +105,7 @@ class TypeNormalizerSpec extends ObjectBehavior
                     ]
                 ]
             ]
-        ])->shouldReturnSubset([
+        ])->shouldContainSubset([
             'type' => 'object',
             'properties' => [
                 'foo' => [
@@ -131,7 +127,7 @@ class TypeNormalizerSpec extends ObjectBehavior
             'properties' => [
                 'foo?' => 'string | number'
             ]
-        ])->shouldBeLike([
+        ])->shouldContainSubset([
             'type' => 'object',
             'properties' => [
                 'foo' => [
@@ -149,7 +145,7 @@ class TypeNormalizerSpec extends ObjectBehavior
     {
         $this->normalize([
             'items' => 'string | number'
-        ])->shouldBeLike([
+        ])->shouldContainSubset([
             'type' => 'array',
             'items' => [
                 'oneOf' => [
@@ -168,7 +164,7 @@ class TypeNormalizerSpec extends ObjectBehavior
                 '/^notes/' => 'number',
                 '//' => 'string'
             ]
-        ])->shouldBeLike([
+        ])->shouldContainSubset([
             'type' => 'object',
             'properties' => [
                 'foo' => ['type' => 'string']
@@ -178,21 +174,5 @@ class TypeNormalizerSpec extends ObjectBehavior
                 '' => ['type' => 'string']
             ]
         ]);
-    }
-
-    public function getMatchers()
-    {
-        return [
-            'returnSubset' => function ($actual, $subset) {
-                $actualSubset = array_intersect_key($actual, $subset);
-
-                if ($actualSubset != $subset) {
-                    echo json_encode($actualSubset, JSON_PRETTY_PRINT);
-                    return false;
-                }
-
-                return true;
-            }
-        ];
     }
 }

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -134,6 +134,16 @@ class TypeNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_supports_null_as_type()
+    {
+        $this->normalize('null')->shouldContainSubset(['type' => 'null']);
+    }
+
+    function it_allows_to_use_empty_value_as_null_type_declaration()
+    {
+        $this->normalize(null)->shouldContainSubset(['type' => 'null']);
+    }
+
     function it_allows_to_use_type_expressions_in_properties()
     {
         $this->normalize([

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -201,6 +201,24 @@ class TypeNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_expands_user_defined_facets()
+    {
+        $this->normalize([
+            'facets' => [
+                'onlyFutureDates?' => 'boolean',
+                'noHolidays' => 'boolean'
+            ]
+        ])->shouldContainSubset([
+            'onlyFutureDates' => [
+                'type' => 'boolean',
+                'required' => false
+            ],
+            'noHolidays' => [
+                'type' => 'boolean'
+            ]
+        ], ['at' => 'facets']);
+    }
+
     function it_supports_property_patterns()
     {
         $this->normalize([

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -40,6 +40,21 @@ class TypeNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_normalize_array_items()
+    {
+        $this->normalize([
+            'items' => [
+                'properties' => []
+            ]
+        ])->shouldReturnSubset([
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'properties' => []
+            ]
+        ]);
+    }
+
     function it_normalizes_object_properties_with_question_mark()
     {
         $this->normalize([

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -7,7 +7,6 @@ use Prophecy\Argument;
 
 class TypeNormalizerSpec extends ObjectBehavior
 {
-
     function it_uses_string_as_default_type()
     {
         $this->normalize([])->shouldContainSubset([
@@ -68,6 +67,20 @@ class TypeNormalizerSpec extends ObjectBehavior
             ], ['at' => 'oneOf']);
     }
 
+    function it_expands_type_declaration_as_type_expression()
+    {
+        $this->normalize('string[] | number[]')
+            ->shouldBeArray([
+                [
+                    'type' => 'array',
+                    'items' => ['type' => 'number']
+                ],
+                [
+                    'type' => 'array',
+                    'items' => ['type' => 'string']
+                ]
+            ], ['at' => 'oneOf']);
+    }
 
     function it_normalizes_object_properties_with_question_mark()
     {

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -160,13 +160,38 @@ class TypeNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_supports_property_patterns()
+    {
+        $this->normalize([
+            'properties' => [
+                'foo' => 'string',
+                '/^notes/' => 'number',
+                '//' => 'string'
+            ]
+        ])->shouldBeLike([
+            'type' => 'object',
+            'properties' => [
+                'foo' => ['type' => 'string']
+            ],
+            'patternProperties' => [
+                '^notes' => ['type' => 'number'],
+                '' => ['type' => 'string']
+            ]
+        ]);
+    }
+
     public function getMatchers()
     {
         return [
             'returnSubset' => function ($actual, $subset) {
                 $actualSubset = array_intersect_key($actual, $subset);
 
-                return $actualSubset == $subset;
+                if ($actualSubset != $subset) {
+                    echo json_encode($actualSubset, JSON_PRETTY_PRINT);
+                    return false;
+                }
+
+                return true;
             }
         ];
     }

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace spec\Fesor\RAML\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TypeNormalizerSpec extends ObjectBehavior
+{
+    function it_uses_string_type_by_default()
+    {
+        $this->normalize([])->shouldReturnSubset([
+            'type' => 'string'
+        ]);
+    }
+
+    function it_uses_object_type_if_properties_defined()
+    {
+        $this->normalize([
+            'properties' => []
+        ])->shouldReturnSubset([
+            'type' => 'object'
+        ]);
+    }
+
+    function it_uses_array_type_if_items_defined()
+    {
+        $this->normalize([
+            'items' => []
+        ])->shouldReturnSubset([
+            'type' => 'array'
+        ]);
+    }
+
+    function it_allows_short_array_declarations()
+    {
+        $this->normalize(['type' => 'Email[]'])->shouldReturnSubset([
+            'type' => 'array',
+            'items' => 'Email'
+        ]);
+    }
+
+    function it_normalizes_object_properties_with_question_mark()
+    {
+        $this->normalize([
+            'properties' => [
+                'foo?' => 'string',
+                'bar??' => 'string',
+                'buz?' => [
+                    'required' => true
+                ]
+            ]
+        ])->shouldReturnSubset([
+            'properties' => [
+                'foo' => [
+                    'type' => 'string',
+                    'required' => false
+                ],
+                'bar?' => [
+                    'type' => 'string',
+                    'required' => false
+                ],
+                'buz?' => [
+                    'type' => 'string',
+                    'required' => true
+                ]
+            ]
+        ]);
+    }
+
+    function it_allow_inplace_type_declaration()
+    {
+        $this->normalize([
+            'properties' => [
+                'foo' => [
+                    'properties' => [
+                        'bar?' => 'string'
+                    ]
+                ]
+            ]
+        ])->shouldReturnSubset([
+            'type' => 'object',
+            'properties' => [
+                'foo' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'bar' => [
+                            'type' => 'string',
+                            'required' => false
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'returnSubset' => function ($actual, $subset) {
+                $actualSubset = array_intersect_key($actual, $subset);
+
+                return $actualSubset == $subset;
+            },
+            'containFacets' => function ($actual, $expectedFacets) {
+                return $actual['facets'] == $expectedFacets;
+            }
+        ];
+    }
+
+}

--- a/tests/spec/Normalizer/TypeNormalizerSpec.php
+++ b/tests/spec/Normalizer/TypeNormalizerSpec.php
@@ -82,6 +82,28 @@ class TypeNormalizerSpec extends ObjectBehavior
             ], ['at' => 'oneOf']);
     }
 
+    function it_expands_nullable_type_expression_as_union_of_types()
+    {
+        $this->normalize('string?')
+            ->shouldBeArray([
+                'oneOf' => [
+                    ['type' => 'null'],
+                    ['type' => 'string']
+                ]
+            ]);
+
+        $this->normalize('string?[]')
+            ->shouldBeArray([
+                'type' => 'array',
+                'items' => [
+                    'oneOf' => [
+                        ['type' => 'null'],
+                        ['type' => 'string']
+                    ]
+                ]
+            ]);
+    }
+
     function it_normalizes_object_properties_with_question_mark()
     {
         $this->normalize([

--- a/tests/spec/RamlSpec.php
+++ b/tests/spec/RamlSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\Fesor\RAML;
+
+use Fesor\RAML\Resource;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RamlSpec extends ObjectBehavior
+{
+    function it_returns_title()
+    {
+        $this->fromArray(['title' => 'My Api']);
+        $this->getTitle()->shouldReturn('My Api');
+    }
+
+    function it_returns_description()
+    {
+        $this->fromArray(['description' => 'My Api Description']);
+        $this->getDescription()->shouldReturn('My Api Description');
+    }
+
+    function it_returns_api_version()
+    {
+        $this->fromArray(['version' => 1]);
+        $this->getVersion()->shouldReturn(1);
+    }
+
+    function it_returns_all_available_resources()
+    {
+        $this->fromArray([
+            'resources' => [
+                [
+                    'uri' => '/users',
+                    'resources' => [
+                        [
+                            'uri' => '/{id}',
+                            'resources' => []
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $this->getAllResources()->shouldContainResources([
+            '/users', '/users/{id}',
+        ]);
+    }
+
+    private function fromArray($raml) {
+        $this->beConstructedThrough('fromArray', [$raml]);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'containResources' => function ($subject, $uris) {
+                $actualUris = array_map(function (Resource $resource) {
+                    return $resource->getAbsoluteUri();
+                }, $subject);
+
+                return $actualUris == $uris;
+            }
+        ];
+    }
+}

--- a/tests/spec/ResourceSpec.php
+++ b/tests/spec/ResourceSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\Fesor\RAML;
+
+use Fesor\RAML\Resource;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ResourceSpec extends ObjectBehavior
+{
+
+    function it_returns_display_name()
+    {
+        $this->fromArray(['uri' => '/users/{id}', 'displayName' => 'user details']);
+        $this->getDisplayName()->shouldReturn('user details');
+    }
+
+    function it_returns_uri_as_default_value_for_display_name()
+    {
+        $this->fromArray(['uri' => '/users/{id}']);
+        $this->getDisplayName()->shouldReturn('/users/{id}');
+    }
+
+    function it_returns_description()
+    {
+        $this->fromArray(['description' => 'description']);
+        $this->getDescription()->shouldReturn('description');
+    }
+
+    function it_returns_sub_resources()
+    {
+        $this->fromArray([]);
+        $this->getSubResources()->shouldReturn([]);
+    }
+
+    function it_returns_uri(Resource $parent)
+    {
+        $this->fromArray(['uri' => '/{id}'], $parent);
+    }
+
+    function it_returns_absolute_uri(Resource $parent)
+    {
+        $parent->getUri()->willReturn('/users');
+        $this->fromArray(['uri' => '/{id}'], $parent);
+
+        $this->getAbsoluteUri()->shouldReturn('/users/{id}');
+    }
+
+    private function fromArray($fragment, Resource $parent = null)
+    {
+        $this->beConstructedThrough('fromArray', [$fragment, $parent]);
+    }
+}

--- a/tests/spec/Type/NumberTypeSpec.php
+++ b/tests/spec/Type/NumberTypeSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class NumberTypeSpec extends ObjectBehavior
+{
+    use TypeSpecTrait;
+
+    function let()
+    {
+        $this->fromArray([
+            'type' => 'number',
+            'minimum' => 4,
+            'maximum' => 100,
+            'format' => 'int64',
+            'multipleOf' => 4,
+        ]);
+    }
+
+    function it_returns_minimum_value()
+    {
+        $this->getMinimum()->shouldReturn(4);
+    }
+
+    function it_returns_maximum_value()
+    {
+        $this->getMaxium()->shouldReturn(100);
+    }
+
+    function it_returns_format()
+    {
+        $this->getFormat()->shouldReturn('int64');
+    }
+
+    function it_returns_multiplie_of()
+    {
+        $this->getMultipleOf()->shouldReturn(4);
+    }
+}

--- a/tests/spec/Type/ObjectTypeSpec.php
+++ b/tests/spec/Type/ObjectTypeSpec.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ObjectTypeSpec extends ObjectBehavior
+{
+    
+}

--- a/tests/spec/Type/ScalarTypeSpec.php
+++ b/tests/spec/Type/ScalarTypeSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use Fesor\RAML\Type\TypeRegistry;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ScalarTypeSpec extends ObjectBehavior
+{
+    use TypeSpecTrait;
+
+    function let()
+    {
+        $this->fromArray([
+            'description' => 'example description',
+            'enum' => ['foo', 'bar']
+        ]);
+    }
+
+
+    function it_returns_description()
+    {
+        $this->getDescription()->shouldReturn('example description');
+    }
+
+    function it_returns_enum_values()
+    {
+        $this->getEnum()->shouldBeLike(['foo', 'bar']);
+    }
+
+}

--- a/tests/spec/Type/StringTypeSpec.php
+++ b/tests/spec/Type/StringTypeSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class StringTypeSpec extends ObjectBehavior
+{
+    use TypeSpecTrait;
+
+    function it_supports_patterns()
+    {
+        $this->fromArray([
+            'pattern' => '^\d+\-\w+$'
+        ]);
+
+        $this->getPattern()->shouldReturn('^\d+\-\w+$');
+    }
+
+    function it_supports_min_length()
+    {
+        $this->fromArray([
+            'minLength' => 1
+        ]);
+
+        $this->getMinLength()->shouldReturn(1);
+    }
+
+    function it_supports_max_length()
+    {
+        $this->fromArray([
+            'maxLength' => 128
+        ]);
+
+        $this->getMaxLength()->shouldReturn(128);
+    }
+}

--- a/tests/spec/Type/TypeRegistrySpec.php
+++ b/tests/spec/Type/TypeRegistrySpec.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class TypeRegistrySpec extends ObjectBehavior
+{
+    function it_can_register_type_declaration()
+    {
+        $this->shouldNotThrow()->duringRegister('name', [
+            'type' => 'string'
+        ]);
+    }
+
+    function it_by_default_contain_integer_type()
+    {
+        $this->shouldNotThrow()->duringResolve('integer');
+    }
+
+    function it_throws_exception_if_type_is_not_registered()
+    {
+        $this->shouldThrow()->duringResolve('not-registered-type');
+    }
+
+    function it_can_register_type_definition_of_string()
+    {
+        $this->shouldNotThrow()->duringRegister('user-defined', [
+            'type' => 'string'
+        ]);
+    }
+
+    function it_can_register_type_definition_of_number()
+    {
+        $this->shouldNotThrow()->duringRegister('user-defined', [
+            'type' => 'number'
+        ]);
+    }
+
+    function it_can_register_type_definition_of_boolean()
+    {
+        $this->shouldNotThrow()->duringRegister('user-defined', [
+            'type' => 'boolean'
+        ]);
+    }
+
+    function it_can_register_type_definition_of_null()
+    {
+        $this->shouldNotThrow()->duringRegister('user-defined', [
+            'type' => 'null'
+        ]);
+    }
+
+    function it_registers_user_defined_objects()
+    {
+        $this->shouldNotThrow()->duringRegister('user-defined', [
+            'type' => 'object',
+            'properties' => [
+                'str' => [
+                    'type' => 'string'
+                ],
+                'obj' => [
+                    'type' => 'object',
+                    'properties'
+                ]
+            ]
+        ]);
+    }
+}

--- a/tests/spec/Type/TypeSpecTrait.php
+++ b/tests/spec/Type/TypeSpecTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use Fesor\RAML\Type\TypeRegistry;
+
+trait TypeSpecTrait
+{
+    protected $registry;
+
+    public function let()
+    {
+        $this->registry = new TypeRegistry();
+    }
+
+    protected function fromArray($typeDefinition)
+    {
+        $this->beConstructedWith('example', array_replace(
+            ['type' => 'string'],
+            $typeDefinition
+        ));
+    }
+}

--- a/tests/spec/Type/UnionTypeSpec.php
+++ b/tests/spec/Type/UnionTypeSpec.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace spec\Fesor\RAML\Type;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UnionTypeSpec extends ObjectBehavior
+{
+    use TypeSpecTrait;
+}

--- a/tests/support/PhpSpec/DeepEqualsMatcher.php
+++ b/tests/support/PhpSpec/DeepEqualsMatcher.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace support\Fesor\RAML\PhpSpec;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\MatcherInterface;
+
+class DeepEqualsMatcher implements MatcherInterface
+{
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'beArray' === $name
+        && 1 <= count($arguments)
+        && (is_array($subject) && is_array($arguments[0]));
+    }
+
+    public function positiveMatch($name, $subject, array $arguments)
+    {
+        if (!$this->isEqual($subject, $arguments)) {
+            throw $this->getError(
+                isset($arguments[1]['at']) ?
+                    $arguments[1]['at'] : []
+            );
+        }
+    }
+
+    public function negativeMatch($name, $subject, array $arguments)
+    {
+        if (!$this->isEqual($subject, $arguments)) {
+            throw $this->getError(
+                isset($arguments[1]['at']) ?
+                    $arguments[1]['at'] : [],
+                $isNegative=true
+            );
+        }
+    }
+
+    public function getPriority()
+    {
+        return 100;
+    }
+
+    private function isEqual(array $subject, array $arguments)
+    {
+        $expected = $arguments[0];
+        $options = isset($arguments[1]) ? $arguments[1] : [];
+
+        if (isset($options['at'])) {
+            $actual = $this->getAtPath($subject, $options['at']);
+        } else {
+            $actual = $subject;
+        }
+
+        $actual = $this->sortArrayKeys($actual);
+        $expected = $this->sortArrayKeys($expected);
+
+        return $actual == $expected;
+    }
+
+    private function sortArrayKeys($data)
+    {
+        if (!is_array($data) && !is_object($data)) {
+            return $data;
+        }
+
+        $orderedData = $data;
+        if (is_array($data)) {
+            ksort($orderedData);
+        }
+
+        foreach ($orderedData as &$value) {
+            $value = $this->sortArrayKeys($value);
+        }
+
+        return $orderedData;
+    }
+
+    private function getAtPath($data, $path)
+    {
+        $pathSegments = explode('/', trim($path, '/'));
+        foreach ($pathSegments as $key) {
+
+            if (is_array($data) && array_key_exists($key, $data)) {
+                $data = $data[$key];
+            } else {
+                throw new \RuntimeException(sprintf('Value doesn\'t have path "%s"', $path));
+            }
+        }
+
+        return $data;
+    }
+
+    private function getError($path, $isNegative=false)
+    {
+        $not = $isNegative ? ' not' : '';
+        $withinPath = $path ? sprintf(' within path "%s"', $path) : '';
+        return new FailureException(
+            sprintf('Expected subject to%s be array with defined structure%s', $not, $withinPath)
+        );
+    }
+}

--- a/tests/support/PhpSpec/Extension.php
+++ b/tests/support/PhpSpec/Extension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace support\Fesor\RAML\PhpSpec;
+
+use PhpSpec\Extension\ExtensionInterface;
+use \PhpSpec\ServiceContainer;
+
+class Extension implements ExtensionInterface
+{
+    public function load(ServiceContainer $container)
+    {
+        $container->set('matchers.includes', function (ServiceContainer $c) {
+            return new SubsetMatcher();
+        });
+        $container->set('matchers.subset_equals', function (ServiceContainer $c) {
+            return new DeepEqualsMatcher();
+        });
+    }
+}

--- a/tests/support/PhpSpec/SubsetMatcher.php
+++ b/tests/support/PhpSpec/SubsetMatcher.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace support\Fesor\RAML\PhpSpec;
+
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\Matcher\MatcherInterface;
+
+class SubsetMatcher implements MatcherInterface
+{
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'containSubset' === $name
+        && 1 <= count($arguments)
+        && (is_array($subject) && is_array($arguments[0]));
+    }
+
+    public function positiveMatch($name, $subject, array $arguments)
+    {
+        if (!$this->isContainsSubset($subject, $arguments)) {
+            throw $this->getError(
+                isset($arguments[1]['at']) ?
+                    $arguments[1]['at'] : []
+            );
+        }
+    }
+
+    public function negativeMatch($name, $subject, array $arguments)
+    {
+        if (!$this->isContainsSubset($subject, $arguments)) {
+            throw $this->getError(
+                isset($arguments[1]['at']) ?
+                    $arguments[1]['at'] : [],
+                $isNegative=true
+            );
+        }
+    }
+
+    public function getPriority()
+    {
+        return 100;
+    }
+
+    private function isContainsSubset(array $subject, array $arguments)
+    {
+        $subset = $arguments[0];
+        $options = isset($arguments[1]) ? $arguments[1] : [];
+
+        if (isset($options['at'])) {
+            $actual = $this->getAtPath($subject, $options['at']);
+        } else {
+            $actual = $subject;
+        }
+
+        $actual = $this->sortArrayKeys($this->deepIntersectKeys($actual, $subset));
+        $expected = $this->sortArrayKeys($subset);
+
+        return $actual == $expected;
+    }
+
+    private function sortArrayKeys($data)
+    {
+        if (!is_array($data) && !is_object($data)) {
+            return $data;
+        }
+
+        $orderedData = $data;
+        if (is_array($data)) {
+            ksort($orderedData);
+        }
+
+        foreach ($orderedData as &$value) {
+            $value = $this->sortArrayKeys($value);
+        }
+
+        return $orderedData;
+    }
+
+    private function getAtPath($data, $path)
+    {
+        $pathSegments = explode('/', trim($path, '/'));
+        foreach ($pathSegments as $key) {
+
+            if (is_array($data) && array_key_exists($key, $data)) {
+                $data = $data[$key];
+            } else {
+                throw new \RuntimeException(sprintf('Value doesn\'t have path "%s"', $path));
+            }
+        }
+
+        return $data;
+    }
+
+    private function deepIntersectKeys(array $subject, array $expected)
+    {
+        $intersection = array_intersect_key($subject, $expected);
+
+        foreach ($intersection as $key => &$value) {
+            if (is_array($expected[$key])) {
+                $value = $this->deepIntersectKeys($value, $expected[$key]);
+            }
+        }
+
+        return $intersection;
+    }
+
+    private function getError($path, $isNegative=false)
+    {
+        $not = $isNegative ? ' not' : '';
+        $withinPath = $path ? sprintf(' within path "%s"', $path) : '';
+        return new FailureException(
+            sprintf('Expected subject to%s include subset%s', $not, $withinPath)
+        );
+    }
+}


### PR DESCRIPTION
Limitations: since this implementation is heavily relies on symfony/yaml, so we can't consider it as true RAML parser. But someday...

Also please note that this version doesn't aims to fully support RAML 1.0. This should be done for 1.0 release. Currently this set of RAML features should be supported:
- Type definitions
- Resource definitions
- Methods definition
- Security Schemas

Here is roadmap for first dev release
- [x] Use symfony/yaml for YAML parsing
- [ ] Normalize input to reduce amount of test cases. Plain arrays used on this stage.
  - [x] Normalize Types
  - [x] Normalize resources
  - [x] Normalize methods
  - [ ] Normalize URI templates and parameters
  - [ ] Normalize security schemas
  - [ ] Trait normalizers
  - [x] Normalize annotations and annotation types
- [ ] Object representation
  - [ ] RAML root object representation
  - [ ] Resource representation
  - [ ] Trait representation
  - [ ] Type definition representation
  - [ ] Methods representation
  - [ ] Request/Response representation
- [ ] json schema generator using type definition as source
